### PR TITLE
Set product name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@converse/desktop",
+  "productName": "Converse Desktop",
   "version": "9.1.0",
   "description": "Desktop Jabber/XMPP client based on Converse.js and Electron",
   "main": "main.js",


### PR DESCRIPTION
Tray icon does not show due to the format of the package name.  Product name will override the package name in electron and allow the tray to show.