### PR TITLE
Add right-click options to tray icon

### DIFF
--- a/app/converse-plugins/desktop-credentials.js
+++ b/app/converse-plugins/desktop-credentials.js
@@ -7,11 +7,12 @@ converse.plugins.add('converse-desktop-credentials', {
         const { api } = _converse;
 
         api.listen.on('afterResourceBinding', () => {
-            if (_converse.connection.pass) {
+            const connection = api.connection.get();
+            if (connection.pass) {
                 credentials.addCredentials(
-                    _converse.connection.service,
+                    connection.service,
                     _converse.bare_jid,
-                    _converse.connection.pass
+                    connection.pass
                 ).catch((reason) => {
                     console.log(reason);
                 });

--- a/modules/tray-service.js
+++ b/modules/tray-service.js
@@ -2,7 +2,7 @@
  * Module for Tray functions.
  */
 
-const {Tray} = require('electron')
+const {Tray, Menu} = require('electron')
 
 const path = require('path')
 
@@ -29,11 +29,21 @@ trayService.initTray = (window) => {
     const iconPath = getTrayServiceIcon()
     tray = new Tray(iconPath)
     tray.setToolTip('Converse Desktop')
-    tray.on('click', function () {
+    tray.on('click', restore)
+
+    if (process.platform === 'linux') {
+        tray.setContextMenu(Menu.buildFromTemplate([
+            {click: restore, role: 'unhide', label: 'Restore'}
+        ]))
+    } else {
+        tray.on('right-click', restore)
+    }
+
+    function restore() {
         window.webContents.send('open-unread-chat')
         trayService.hideEnvelope()
         window.show()
-    })
+    }
 }
 
 trayService.showEnvelope = () => {


### PR DESCRIPTION
On windows and MacOS, open the application when right-clicking the tray icon. 

On linux (mint), a menu is necessary so add a single-item menu to restore the application.
